### PR TITLE
fix: guard the external shortcode against a missing file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: The `external` shortcode no longer stops the render when it is called with no file path. It reports the missing argument and includes nothing. (#53)
+
 ## 1.8.0 (2026-09-07)
 
 ### New Features

--- a/_extensions/external/external.lua
+++ b/_extensions/external/external.lua
@@ -299,6 +299,14 @@ end
 local function include_external(args, kwargs, _meta, _raw_args, _context)
   checker:call('external', args, kwargs)
 
+  if #args == 0 then
+    log.log_warning(
+      EXTENSION_NAME,
+      'The external shortcode requires a file path as its first argument. Nothing was included.'
+    )
+    return pandoc.Null()
+  end
+
   --- @type string File URI to include
   local uri = pandoc.utils.stringify(args[1])
   --- @type string|nil Raw fragment after `#`, if present


### PR DESCRIPTION
Calling the shortcode with no arguments stopped the whole render with `Cannot get Attr from TypeNil`. It now reports the missing path and includes nothing.